### PR TITLE
Avoid warnings

### DIFF
--- a/WDS_Taxonomy_Radio.class.php
+++ b/WDS_Taxonomy_Radio.class.php
@@ -42,6 +42,9 @@ if ( !class_exists( 'WDS_Taxonomy_Radio' ) ) {
 			 * Removes and replaces the built-in taxonomy metabox with our own.
 			 */
 			public function add_radio_box() {
+				 //test the taxonomy slug construtor is an actual taxonomy
+				 if ( !$this->taxonomy() ) return;
+			
 				 foreach ( $this->post_types() as $key => $cpt ) {
 						// remove default category type metabox
 						remove_meta_box( $this->slug .'div', $cpt, 'side' );
@@ -132,7 +135,9 @@ if ( !class_exists( 'WDS_Taxonomy_Radio' ) ) {
 
 	 }
 
-	 $custom_tax_mb = new WDS_Taxonomy_Radio( 'custom-tax-slug' );
+	 // Usage:
+
+	 // $custom_tax_mb = new WDS_Taxonomy_Radio( 'custom-tax-slug' );
 
 	 // Update optional properties
 


### PR DESCRIPTION
Test that the taxonomy slug is an actual taxonomy before adding the
meta box.
The default code produced a warning:
Warning: Invalid argument supplied for foreach()

This happens when used with an invalid taxonomy, which is default with
the
$custom_tax_mb = new WDS_Taxonomy_Radio('custom-tax-slug')
at the end of the code.
This demo line could be commented out, considering it is useful to keep
the configuration code in functions.php, next to the include of the
class, instead of inside the class file. One doesn't need to read the
entire code, when there is excellent instructions in the readme!
