### PR TITLE
WP-SEO display fix

### DIFF
--- a/WDS_Taxonomy_Radio.class.php
+++ b/WDS_Taxonomy_Radio.class.php
@@ -123,7 +123,7 @@ class WDS_Taxonomy_Radio {
 
 		require_once( 'WDS_Taxonomy_Radio_Walker.php' );
 
-		$class = $this->indented ? 'categorydiv' : 'not-indented';
+		$class = $this->indented ? 'taxonomydiv' : 'not-indented';
 		$class .= 'category' !== $this->slug ? ' '. $this->slug .'div' : '';
 		$class .= ' tabs-panel';
 		?>


### PR DESCRIPTION
Don't ask me why ( assuming Javascript ) was causing an error when using the class `categorydiv`.  I changed this to `taxonomydiv` and it works fine.  

This Fixes issue #4
