### PR TITLE
support hierarchical indentation in select element.

### DIFF
--- a/walker.taxonomy-single-term.php
+++ b/walker.taxonomy-single-term.php
@@ -87,7 +87,8 @@ class Taxonomy_Single_Term_Walker extends Walker {
 			'checked'       => checked( $in_selected, true, false ),
 			'selected'      => selected( $in_selected, true, false ),
 			'disabled'      => disabled( empty( $args['disabled'] ), false, false ),
-			'label'         => esc_html( apply_filters('the_category', $term->name ) )
+			'label'         => esc_html( apply_filters('the_category', $term->name ) ),
+			'depth'         => $depth,
 		);
 
 		$output .= 'radio' == $this->input_element
@@ -127,13 +128,15 @@ class Taxonomy_Single_Term_Walker extends Walker {
 	 * @return string       Opening option element and option text
 	 */
 	public function start_el_select( $args ) {
+		$pad = str_repeat('&nbsp;', $args['depth'] * 3);
+
 		return "\n".sprintf(
 			'<option %s %s id="%s" value="%s" class="class-single-term">%s',
 			$args['selected'],
 			$args['disabled'],
 			$args['id'],
 			$args['value'],
-			$args['label']
+			$pad . $args['label']
 		);
 	}
 


### PR DESCRIPTION
Current codebase doesn't support indentation in the select dropdown for hierarchical taxonomies. For example, consider the following taxonomy:

Term 1
    Subterm 1.a
    Subterm 1.b
Term 2

Select dropdown will show up as:
Term 1
Subterm 1.a
Subterm 1.b
Term 2

This pull request mimics class Walker_CategoryDropdown from WordPress core to add indentation.
