### PR TITLE
Fix radios in quick-edit

### DIFF
--- a/class.taxonomy-single-term.php
+++ b/class.taxonomy-single-term.php
@@ -434,7 +434,7 @@ class Taxonomy_Single_Term {
 				$theList.find('.editinline').on( 'click', function() {
 					var $this = $(this);
 					setTimeout( function() {
-						var $editRow = $this.parents( 'tr' ).next();
+						var $editRow = $this.parents( 'tr' ).next().next();
 						changeToRadio( $editRow );
 					}, 50 );
 				});


### PR DESCRIPTION
Additional next() to choose correct <tr> row (not the hidden one)