### PR TITLE
Update to allow for a Default to be set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Taxonomy_Single_Term
 ==================
 
-Version: 0.2.1
+Version: 0.2.2
 
 Taxonomies in WordPress are super powerful. The purpose of taxonomies is to create relationships among post types. Unfortunately the UI doesn't effectively enforce limiting to a single term.
 
@@ -17,8 +17,11 @@ Usage
 	`$custom_tax_mb = new Taxonomy_Single_Term( 'custom-tax-slug' );`
 
 #### Optional
-1. Second parameter is an array of post\_types and the third parameter is either 'radio', or 'select' (defaulting to radio). To use a `select` type on the `foo` post\_type:
+1. 
+   * Second parameter is an array of post\_types, 
+   * The third parameter is either 'radio', or 'select' (defaulting to radio). To use a `select` type on the `foo` post\_type:
 	`$custom_tax_mb = new Taxonomy_Single_Term( 'custom-tax-slug', array( 'foo' ), 'select' );`
+   * The fourth parameter is the default to select for posts that have not had the taxonomy set. This defaults to the system default option where available and falls back to none where not.
 2. Update optional class properties like:
 ```php
 // Priority of the metabox placement.
@@ -38,9 +41,19 @@ $custom_tax_mb->set( 'indented', false );
 
 // Allows adding of new terms from the metabox
 $custom_tax_mb->set( 'allow_new_terms', true );
+
+// set default
+$custom_tax_mb->set( 'default', 'default-slug' ); // or
+$custom_tax_mb->set( 'default', 'Default Name' ); // or
+$custom_tax_mb->set( 'default', 123 ); // default term_id
+
 ```
 
 #### Change Log
+**0.2.2**
+* Add default to options. Props [@BinaryKitten](https://github.com/BinaryKitten)
+* Add default setter
+
 **0.2.1**
 * Add setter method. Props [@JustinSainton](https://github.com/JustinSainton)
 * Add getter magic method for retrieving properties

--- a/class.taxonomy-single-term.php
+++ b/class.taxonomy-single-term.php
@@ -118,7 +118,7 @@ class Taxonomy_Single_Term {
 	 * @since 0.2.2
 	 * @var array
 	 */
-	protected $default = [];
+	protected $default = array();
 
 	/**
 	 * Initiates our metabox action
@@ -157,7 +157,7 @@ class Taxonomy_Single_Term {
 		$default = (array) $default;
 
 		if ( empty( $default ) ) {
-			$default = [ (int) get_option( 'default_' . $tax_slug ) ];
+			$default = array( (int) get_option( 'default_' . $tax_slug ) );
 		}
 
 		foreach ( $default as $index => $default_item ) {

--- a/class.taxonomy-single-term.php
+++ b/class.taxonomy-single-term.php
@@ -293,13 +293,28 @@ class Taxonomy_Single_Term {
 	 * @since  0.2.0
 	 */
 	public function term_fields_list() {
-		wp_terms_checklist( get_the_ID(), array(
-			'taxonomy'      => $this->slug,
-			'selected_cats' => $this->default,
-			'popular_cats'  => false,
-			'checked_ontop' => false,
-			'walker'        => $this->walker(),
-		) );
+		$default = wp_get_post_terms(
+			get_the_ID(),
+			$this->slug
+		);
+		
+		if ( is_wp_error( $default ) ) {
+			$default = array();
+		}
+		
+		$default[] = $this->default;
+		$default   = (array) current( $default );
+
+		wp_terms_checklist(
+			get_the_ID(),
+			array(
+				'taxonomy'      => $this->slug,
+				'selected_cats' => $default,
+				'popular_cats'  => false,
+				'checked_ontop' => false,
+				'walker'        => $this->walker(),
+			)
+		);
 	}
 
 	/**

--- a/class.taxonomy-single-term.php
+++ b/class.taxonomy-single-term.php
@@ -145,13 +145,23 @@ class Taxonomy_Single_Term {
 		}
 	}
 	
-	protected function process_default($default = array(), $tax_slug)  {
+	/**
+	 * Process default value for settings
+	 * 
+	 * @param array $default
+	 * @param $tax_slug
+	 *
+	 * @return array
+	 */
+	protected function process_default( $default = array(), $tax_slug ) {
+		$default = (array) $default;
+
 		if ( empty( $default ) ) {
 			$default = [ (int) get_option( 'default_' . $tax_slug ) ];
 		}
-		
+
 		foreach ( $default as $index => $default_item ) {
-			if ( is_numeric( $default_item) ) {
+			if ( is_numeric( $default_item ) ) {
 				continue;
 			}
 			$term = get_term_by( 'slug', $default_item, $tax_slug );
@@ -160,7 +170,7 @@ class Taxonomy_Single_Term {
 			}
 			$default[ $index ] = ( $term instanceof WP_Term ) ? $term->term_id : false;
 		}
-		
+
 		return array_filter( $default );
 	}
 	
@@ -590,9 +600,15 @@ class Taxonomy_Single_Term {
 	 */
 	public function set( $property, $value ) {
 
-		if ( property_exists( $this, $property ) ) {
-			$this->$property = $value;
+		if ( ! property_exists( $this, $property ) ) {
+			return $this;
 		}
+
+		if ( 'default' === $property ) {
+			$value = $this->process_default( $value, $this->taxonomy );
+		}
+
+		$this->$property = $value;
 
 		return $this;
 	}

--- a/class.taxonomy-single-term.php
+++ b/class.taxonomy-single-term.php
@@ -133,7 +133,7 @@ class Taxonomy_Single_Term {
 		$this->slug = $tax_slug;
 		$this->post_types = is_array( $post_types ) ? $post_types : array( $post_types );
 		$this->input_element = in_array( (string) $type, array( 'radio', 'select' ) ) ? $type : $this->input_element;
-		$this->default = $this->process_default( $default, $tax_slug );
+		$this->default = $this->process_default( $default );
 
 		add_action( 'add_meta_boxes', array( $this, 'add_input_element' ) );
 		add_action( 'admin_footer', array( $this, 'js_checkbox_transform' ) );
@@ -153,20 +153,20 @@ class Taxonomy_Single_Term {
 	 *
 	 * @return array
 	 */
-	protected function process_default( $default = array(), $tax_slug ) {
+	protected function process_default( $default = array() ) {
 		$default = (array) $default;
 
 		if ( empty( $default ) ) {
-			$default = array( (int) get_option( 'default_' . $tax_slug ) );
+			$default = array( (int) get_option( 'default_' . $this->slug ) );
 		}
 
 		foreach ( $default as $index => $default_item ) {
 			if ( is_numeric( $default_item ) ) {
 				continue;
 			}
-			$term = get_term_by( 'slug', $default_item, $tax_slug );
+			$term = get_term_by( 'slug', $default_item, $this->tax_slug );
 			if ( $term === false ) {
-				$term = get_term_by( 'name', $default_item, $tax_slug );
+				$term = get_term_by( 'name', $default_item, $this->tax_slug );
 			}
 			$default[ $index ] = ( $term instanceof WP_Term ) ? $term->term_id : false;
 		}
@@ -620,7 +620,7 @@ class Taxonomy_Single_Term {
 		}
 
 		if ( 'default' === $property ) {
-			$value = $this->process_default( $value, $this->slug );
+			$value = $this->process_default( $value );
 		}
 
 		$this->$property = $value;

--- a/class.taxonomy-single-term.php
+++ b/class.taxonomy-single-term.php
@@ -620,7 +620,7 @@ class Taxonomy_Single_Term {
 		}
 
 		if ( 'default' === $property ) {
-			$value = $this->process_default( $value, $this->taxonomy );
+			$value = $this->process_default( $value, $this->slug );
 		}
 
 		$this->$property = $value;


### PR DESCRIPTION
Update the Taxonomy Single Term to allow a default to be specified, and if it's not found, fall back to the option for the default.
This is a better situation for new Posts where it hasn't been set and where the 1st item Alphabetically isn't the desired default.