### PR TITLE
Remove the term_taxonomy_id from the term array. 

### DIFF
--- a/class.taxonomy-single-term.php
+++ b/class.taxonomy-single-term.php
@@ -301,8 +301,9 @@ class Taxonomy_Single_Term {
 			$default = array();
 		}
 
-		$default[] = $this->default;
+		//$default[] = $this->default;
 		$default   = (array) current( $default );
+		unset ($default['term_taxonomy_id']);
 
 		wp_terms_checklist(
 			get_the_ID(),


### PR DESCRIPTION
The existence of this id can interfere with the _selected_ function.
terms:

 id | name 
 ---: | ------------- |
 10 | so so 
 11 | the best 

taxonomy:

id |name
---: | -------------
1 | qualification

term_taxonomy:

id | taxonomy_id | term_id
---: | ------------: | -------:
11|  1 | 10 
12 | 1 | 11

suppose a post has term 10 attached from taxonomy 1, the $default array now holds
term_id => 10, name => "so so", slug => "so-so", term_group => 0, term_taxonomy_id => 11, ...
the function selected checks whether the current term_id is in the array presented above, which is both treu for term 10 and 11.