### PR TITLE
Walker class attribute escape

### DIFF
--- a/walker.taxonomy-single-term.php
+++ b/walker.taxonomy-single-term.php
@@ -81,9 +81,9 @@ class Taxonomy_Single_Term_Walker extends Walker {
 		$in_selected   = in_array( $term->term_id, $selected_cats );
 
 		$args = array(
-			'id'            => $taxonomy .'-'. $term->term_id,
-			'name'          => $name,
-			'value'         => $value,
+			'id'            => esc_attr( $taxonomy .'-'. $term->term_id ),
+			'name'          => esc_attr( $name ),
+			'value'         => esc_attr( $value ),
 			'checked'       => checked( $in_selected, true, false ),
 			'selected'      => selected( $in_selected, true, false ),
 			'disabled'      => disabled( empty( $args['disabled'] ), false, false ),


### PR DESCRIPTION
As the data are coming from WordPress background, escaping attributes aren't that necessary. But I think best practice is where ever the data are coming form, that should be escaped and validated before storing in to database and presenting. So escaping the attributes are better here.