### PR TITLE
Change package type to wordpress-plugin.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "webdevstudios/taxonomy_single_term",
     "description": "Removes and replaces the built-in taxonomy WordPress metabox with a radio or select metabox.",
-    "type": "library",
+    "type": "wordpress-plugin",
     "keywords": ["wordpress","metabox","terms","taxonomy"],
     "homepage": "http://webdevstudios.com/"
 }


### PR DESCRIPTION
[`composer/installers`](https://github.com/composer/installers) natively supports `"type": "wordpress-plugin"` to have plugins installed in the right directory.